### PR TITLE
Added option `manual_exit` for web frontend.

### DIFF
--- a/Tank/Plugins/WebOnline.py
+++ b/Tank/Plugins/WebOnline.py
@@ -3,6 +3,7 @@ from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
 from Tank.Plugins.Aggregator import AggregatorPlugin, AggregateResultListener
 from tankcore import AbstractPlugin
 from threading import Thread
+from distutils.util import strtobool
 import json
 import logging
 import os.path
@@ -30,11 +31,13 @@ class WebOnlinePlugin(AbstractPlugin, Thread, AggregateResultListener):
         self.codes_data = []
         self.avg_data = []
         self.redirect = ''
+        self.manual_stop = False
     
     def configure(self):
         self.port = int(self.get_option("port", self.port))
         self.interval = int(tankcore.expand_to_seconds(self.get_option("interval", '1m')))
         self.redirect = self.get_option("redirect", self.redirect)
+        self.manual_stop = strtobool(self.get_option('manual_stop', self.manual_stop))
     
     def prepare_test(self):
         self.server = OnlineServer(('', self.port), WebOnlineHandler)
@@ -48,6 +51,9 @@ class WebOnlinePlugin(AbstractPlugin, Thread, AggregateResultListener):
     def end_test(self, retcode):
         #self.log.info("Shutting down local server")
         #self.server.shutdown() don't enable it since it leads to random deadlocks
+        if self.manual_stop:
+            raw_input('Press Enter, to close webserver.')
+
         if self.redirect:
             time.sleep(2)
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -63,6 +63,19 @@ autostop=time(1,10) short\_only=1 time\_periods=10 20 30 100
 job\_name=ask \`\`\` !!! Don't use global options wich have same name in
 different sections.
 
+The ``web`` section
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Here are default options, controlling a yandex tank's web frontend::
+
+    [web]
+    port = 8080      # a port to bind to on localhost
+    interval = 1m    # ???
+    redirect = ""    # does nothing except 2 seconds delay on exit
+    # if 'yes', then webserver will wait for Enter from keyboard
+    # to exit
+    manual_stop = no
+
 Multiline options
 ^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
By default, this feature is switched off. But when
you enable it, webserver will wait for Enter from
keyboard. This way, you will be able to investigate
you graphs after the end of the test.
