### PR TITLE
Fix for ammos format description

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -158,10 +158,10 @@ is:
 
   [size_of_request] [tag]\n
   [request_headers]
-  [body_of_request] \r\n
+  [body_of_request]\r\n
   [size_of_request2] [tag2]\n
   [request2_headers]
-  [body_of_request2] \r\n
+  [body_of_request2]\r\n
 
 
 where ``size_of_request`` – request size in bytes. '\r\n' symbols after


### PR DESCRIPTION
Spacebar between POST body and \r\n sequense is wrong, phantom reacts with error on it.
