### PR TITLE
Fix problem with GNU awk

### DIFF
--- a/Tank/MonCollector/agent/agent.py
+++ b/Tank/MonCollector/agent/agent.py
@@ -382,7 +382,7 @@ class NetTcp(AbstractMetric):
         if note set it to 0.
         * make output ordered as "fields" list
         """
-        fetch = lambda: commands.getoutput("ss -s | awk -F'\(|\)|\/' '/^TCP:/ {print $2}'")
+        fetch = lambda: commands.getoutput("ss -s | sed -ne 's/).*//;/^TCP/s/^[^(]*(//p'")
         data = {}
         result = []
         raw_lines = fetch().split(',')


### PR DESCRIPTION
Fixes problem of parsing "ss -s" with GNU version of awk, and therefor fixes problem with closed/established/timewait counters in monitoring (old one works with mawk, but not gawk, which is default for CentOS).
