### PR TITLE
Explicitly run yandex-tank python scripts with python2

### DIFF
--- a/Tank/MonCollector/agent/agent.py
+++ b/Tank/MonCollector/agent/agent.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/env python2
 """ The agent bundle, contains all metric classes and agent running code """
 from optparse import OptionParser
 import base64

--- a/Tank/MonCollector/collector.py
+++ b/Tank/MonCollector/collector.py
@@ -93,7 +93,7 @@ class AgentClient(object):
         self.custom = {}
         self.startups = []
         self.shutdowns = []
-        self.python = '/usr/bin/env python'
+        self.python = '/usr/bin/env python2'
 
     def start(self):
         """        Start remote agent        """
@@ -458,7 +458,7 @@ class MonitoringCollector:
         if host.get('python'):
             tmp.update({'python': host.get('python')})
         else:
-            tmp.update({'python': '/usr/bin/env python'})
+            tmp.update({'python': '/usr/bin/env python2'})
 
         tmp.update({'custom': custom})
         tmp.update({'host': hostname})

--- a/tank.py
+++ b/tank.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/env python2
 from Tank.ConsoleWorker import ConsoleTank, CompletionHelperOptionParser
 from optparse import OptionParser
 import logging


### PR DESCRIPTION
The issue with using just `/usr/bin/env python` raises when default system python is python3. In this case Yandex Tank fails to run since it still has no supports of modern Python. Telling him explicitly use python2 solves the issue and makes Yandex Tank ready for the battle on modern OS.
