### PR TITLE
Fix Monitoring.collector

### DIFF
--- a/tests/MonitoringTest.py
+++ b/tests/MonitoringTest.py
@@ -9,8 +9,14 @@ import time
 import tempfile
 
 
-class  MonitoringCollectorTestCase(TankTestCase):
+class MonitoringCollectorTestCase(TankTestCase):
     data = None
+
+    def test_config(self):
+        mon = MonitoringCollector()
+        conf = mon.getconfig("config/mon1.conf", 'localhost')
+        # XXX: write a better test
+        assert conf
 
     def test_collector(self):
         mon = MonitoringCollector()

--- a/yandextank/plugins/Monitoring/collector.py
+++ b/yandextank/plugins/Monitoring/collector.py
@@ -32,7 +32,7 @@ class Config(object):
     def loglevel(self):
         """Get log level from config file. Possible values: info, debug"""
         log_level = 'info'
-        log_level_raw = self.tree.find('./Monitoring').get('loglevel')
+        log_level_raw = self.tree.getroot().get('loglevel')
         if log_level_raw in ('info', 'debug'):
             log_level = log_level_raw
         return log_level
@@ -481,7 +481,7 @@ class MonitoringCollector:
             logging.error("Error loading config: %s", exc)
             raise RuntimeError("Can't read monitoring config %s" % filename)
 
-        hosts = tree.findall('./Monitoring/Host')
+        hosts = tree.findall('Host')
         names = defaultdict()
         config = []
 

--- a/yandextank/plugins/Monitoring/collector.py
+++ b/yandextank/plugins/Monitoring/collector.py
@@ -386,7 +386,7 @@ class MonitoringCollector:
             listener.monitoring_data(self.send_data)
         self.send_data = ''
 
-    def get_host_config(self, filter_obj, host, names, target_hint):
+    def get_host_config(self, host, names, target_hint):
 
         default = {
             'System': 'csw,int',
@@ -440,8 +440,8 @@ class MonitoringCollector:
 
         logging.debug("Metrics count: %s", metrics_count)
         logging.debug("Host len: %s", len(host))
-        logging.debug("keys: %s", host.keys())
-        logging.debug("values: %s", host.values())
+        logging.debug("keys: %s", host.attrib.keys())
+        logging.debug("values: %s", host.attrib.values())
 
         # use default metrics for host
         if metrics_count == 0:


### PR DESCRIPTION
The xml.etree.ElementTree.find/findall method don't need the root element in path.

// сломал мониторинг при выпиливании lxml, надо было все-таки нормально проверить
// test coming soon...