### PR TITLE
Fix jmeter jtl log writing

### DIFF
--- a/yandextank/plugins/JMeter/plugin.py
+++ b/yandextank/plugins/JMeter/plugin.py
@@ -63,7 +63,7 @@ class JMeterPlugin(AbstractPlugin):
 
     def prepare_test(self):
         self.args = [self.jmeter_path, "-n", "-t", self.jmx, '-j', self.jmeter_log,
-                     '-Jjmeter.save.saveservice.default_delimiter=\\t']
+                     '-Jjmeter.save.saveservice.default_delimiter=\\t', "-l", self.jtl_file]
         self.args += tankcore.splitstring(self.user_args)
 
         aggregator = None


### PR DESCRIPTION
При запуске jmeter тестов через yandex-tank вижу ошибку:
17:00:45 WARNING: Empty results file, skip Loadosophia.org uploading: /var/www/project_loadtests/yandex_tank/logs/jmeter_zaBCDZ.jtl

В результате данные не загружаются в Loadosophia.org.

