### PR TITLE
Http opener

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ analytic tools for the results they produce.
         'psutil',
         'ipaddr',
         'progressbar',
+        'requests',
     ],
     license='LGPLv2',
     classifiers=[

--- a/yandextank/stepper/main.py
+++ b/yandextank/stepper/main.py
@@ -229,21 +229,9 @@ class StepperWrapper(object):
             hashed_str += sep + str(self.enum_ammo)
             if self.instances_schedule:
                 hashed_str += sep + str(self.instances)
-
             if self.ammo_file:
-                if not os.path.exists(self.ammo_file):
-                    raise RuntimeError(
-                        "Ammo file not found: %s" % self.ammo_file)
-
-                hashed_str += sep + os.path.realpath(self.ammo_file)
-                stat = os.stat(self.ammo_file)
-                cnt = 0
-                for stat_option in stat:
-                    if cnt == 7:  # skip access time
-                        continue
-                    cnt += 1
-                    hashed_str += ";" + str(stat_option)
-                hashed_str += ";" + str(os.path.getmtime(self.ammo_file))
+                opener = get_opener(self.ammo_file)
+                hashed_str += sep + opener.hash
             else:
                 if not self.uris:
                     raise RuntimeError(

--- a/yandextank/stepper/missile.py
+++ b/yandextank/stepper/missile.py
@@ -6,7 +6,6 @@ You should update Stepper.status.ammo_count and Stepper.status.loop_count in you
 from util import get_opener
 from itertools import cycle
 from module_exceptions import AmmoFileError
-import os.path
 import info
 import logging
 
@@ -105,8 +104,9 @@ class AmmoFileReader(object):
                     return line
                 chunk_header = line.strip('\r\n')
             return chunk_header
-        with get_opener(self.filename)(self.filename, 'rb') as ammo_file:
-            info.status.af_size = os.path.getsize(self.filename)
+        opener = get_opener(self.filename) 
+        with opener(self.filename, 'rb') as ammo_file:
+            info.status.af_size = opener.data_length
             chunk_header = read_chunk_header(ammo_file) #  if we got StopIteration here, the file is empty
             while chunk_header:
                 if chunk_header is not '':
@@ -145,8 +145,9 @@ class SlowLogReader(object):
         self.filename = filename
 
     def __iter__(self):
-        with open(self.filename, 'rb') as ammo_file:
-            info.status.af_size = os.path.getsize(self.filename)
+        opener = get_opener(self.filename) 
+        with opener(self.filename, 'rb') as ammo_file:
+            info.status.af_size = opener.data_length
             request = ""
             while True:
                 for line in ammo_file:
@@ -169,7 +170,9 @@ class LineReader(object):
         self.filename = filename
 
     def __iter__(self):
-        with get_opener(self.filename)(self.filename, 'rb') as ammo_file:
+        opener = get_opener(self.filename) 
+        with opener(self.filename, 'rb') as ammo_file:
+            info.status.af_size = opener.data_length
             while True:
                 for line in ammo_file:
                     info.status.af_position = ammo_file.tell()
@@ -196,7 +199,9 @@ class AccessLogReader(object):
         self.log.debug(message)
 
     def __iter__(self):
-        with get_opener(self.filename)(self.filename, 'rb') as ammo_file:
+        opener = get_opener(self.filename) 
+        with opener(self.filename, 'rb') as ammo_file:
+            info.status.af_size = opener.data_length
             while True:
                 for line in ammo_file:
                     info.status.af_position = ammo_file.tell()
@@ -230,7 +235,9 @@ class UriReader(object):
         self.log.info("Loading ammo from '%s' using URI format." % filename)
 
     def __iter__(self):
-        with get_opener(self.filename)(self.filename, 'rb') as ammo_file:
+        opener = get_opener(self.filename) 
+        with opener(self.filename, 'rb') as ammo_file:
+            info.status.af_size = opener.data_length
             while True:
                 for line in ammo_file:
                     info.status.af_position = ammo_file.tell()
@@ -279,8 +286,9 @@ class UriPostReader(object):
                 else:
                     chunk_header = line.strip('\r\n')
             return chunk_header
-        with get_opener(self.filename)(self.filename, 'rb') as ammo_file:
-            info.status.af_size = os.path.getsize(self.filename)
+        opener = get_opener(self.filename) 
+        with opener(self.filename, 'rb') as ammo_file:
+            info.status.af_size = opener.data_length
             chunk_header = read_chunk_header(ammo_file) #  if we got StopIteration here, the file is empty
             while chunk_header:
                 if chunk_header is not '':

--- a/yandextank/stepper/util.py
+++ b/yandextank/stepper/util.py
@@ -155,16 +155,16 @@ class HttpOpener(object):
             self._detect_gzip()
             if not self.gzip \
             and not self.data_length or not str(self.data_length).isdigit() or int(self.data_length) > 10**8):
-            	logging.info("Ammofile data is larger than 100MB. Reading from stream..")
+                logging.info("Ammofile data is larger than 100MB. Reading from stream..")
                 return HttpStreamWrapper(self.url)
             else:
                 hasher = hashlib.md5()
                 hasher.update(self.hash)
                 tmpfile_path = "/tmp/%s" % hasher.hexdigest()
                 if os.path.exists(tmpfile_path):
-                	logging.info("Ammofile has already been downloaded to %s . Using it..", tmpfile_path)
+                    logging.info("Ammofile has already been downloaded to %s . Using it..", tmpfile_path)
                 else:
-                	logging.info("Downloading ammofile to %s", tmpfile_path)
+                    logging.info("Downloading ammofile to %s", tmpfile_path)
                     data = requests.get(self.url)
                     f = open(tmpfile_path, "wb")
                     f.write(data.content)
@@ -184,12 +184,12 @@ class HttpOpener(object):
                 stream_iterator = stream.raw.stream(2, decode_content=True)
                 gz_header = stream_iterator.next()
                 if gz_header[:2] == b'\037\213':
-					logging.info("Ammofile data is in gz format")
+                    logging.info("Ammofile data is in gz format")
                     self.gzip = True
             except:
                 logging.exception("")
-			finally:
-				stream.connection.close()
+            finally:
+                stream.connection.close()
     
     @property
     def hash(self):
@@ -198,10 +198,10 @@ class HttpOpener(object):
     
     @property
     def data_length(self): 
-		try:
-			data_length = int(self.data_info.headers.get("Content-Length", 0))
-		except:
-			data_length = 0
+        try:
+            data_length = int(self.data_info.headers.get("Content-Length", 0))
+        except:
+            data_length = 0
         return data_length
     
     
@@ -254,7 +254,7 @@ class HttpStreamWrapper():
                 self._enhance_buffer()
             except (StopIteration, TypeError, requests.exceptions.StreamConsumedError):
                 self._content_consumed = True
-		        break
+                break
         if not self._content_consumed or self.buffer:
     	    try:
                 line = self.buffer[:self.buffer.index('\n')+1]

--- a/yandextank/stepper/util.py
+++ b/yandextank/stepper/util.py
@@ -162,9 +162,9 @@ class HttpOpener(object):
                 hasher.update(self.hash)
                 tmpfile_path = "/tmp/%s" % hasher.hexdigest()
                 if os.path.exists(tmpfile_path):
-					logging.info("Ammofile has already been downloaded to %s . Using it..", tmpfile_path)
-				else:
-					logging.info("Downloading ammofile to %s", tmpfile_path)
+                	logging.info("Ammofile has already been downloaded to %s . Using it..", tmpfile_path)
+                else:
+                	logging.info("Downloading ammofile to %s", tmpfile_path)
                     data = requests.get(self.url)
                     f = open(tmpfile_path, "wb")
                     f.write(data.content)
@@ -258,8 +258,8 @@ class HttpStreamWrapper():
         if not self._content_consumed or self.buffer:
     	    try:
                 line = self.buffer[:self.buffer.index('\n')+1]
-    	    except ValueError:
-        		line = self.buffer
+            except ValueError:
+            	line = self.buffer
             self.pointer += len(line)
             self.buffer = self.buffer[len(line):]
             return line

--- a/yandextank/stepper/util.py
+++ b/yandextank/stepper/util.py
@@ -257,7 +257,7 @@ class HttpStreamWrapper():
 		        break
         if not self._content_consumed or self.buffer:
     	    try:
-                    line = self.buffer[:self.buffer.index('\n')+1]
+                line = self.buffer[:self.buffer.index('\n')+1]
     	    except ValueError:
         		line = self.buffer
             self.pointer += len(line)

--- a/yandextank/stepper/util.py
+++ b/yandextank/stepper/util.py
@@ -7,7 +7,11 @@ from itertools import islice
 from module_exceptions import StepperConfigurationError
 import math
 import gzip
+import requests
+import os
+import hashlib
 
+logging.getLogger("requests").setLevel(logging.WARNING)
 
 def take(number, iter):
     return list(islice(iter, 0, number))
@@ -60,17 +64,230 @@ def s_to_ms(f_sec):
 
 
 def get_opener(f_path):
-    """ Returns opener function according to file extensions:
-        bouth open and gzip.open calls return fileobj.
+    """ Returns sub_opener function according to file extensions:
+        both open and gzip.open calls return fileobj.
 
     Args:
-        f_path: str, ammo file path.
+        f_path: str, ammo file url.
 
     Returns:
-        function, to call for file open.
+        object, to call for file open.
     """
-    if f_path.endswith('.gz'):
-        logging.info("Using gzip opener")
-        return gzip.open
+    if f_path.startswith("http://") or f_path.startswith("https://"):
+        opener = HttpOpener(f_path)
+    elif f_path.endswith('.gz'):
+        opener = GZOpener(f_path)
     else:
-        return open
+        opener = FSOpener(f_path)
+    return opener
+
+
+class GZOpener(object):
+    
+    def __init__(self, f_path):
+        self.f_path = f_path
+    
+    def __call__(self, *args, **kwargs):
+        return gzip.open(*args, **kwargs)
+    
+    @property
+    def hash(self):
+        sep = "|"
+        hashed_str = os.path.realpath(self.f_path)
+        stat = os.stat(self.f_path)
+        cnt = 0
+        for stat_option in stat:
+            if cnt == 7:  # skip access time
+                continue
+            cnt += 1
+            hashed_str += ";" + str(stat_option)
+        hashed_str += ";" + str(os.path.getmtime(self.f_path))
+        return hashed_str 
+    
+    @property
+    def data_length(self): 
+        return os.path.getsize(self.f_path)
+
+class FSOpener(object):
+    
+    def __init__(self, f_path):
+        self.f_path = f_path
+    
+    def __call__(self, *args, **kwargs):
+        return open(*args, **kwargs)
+    
+    @property
+    def hash(self):
+        sep = "|"
+        hashed_str = os.path.realpath(self.f_path)
+        stat = os.stat(self.f_path)
+        cnt = 0
+        for stat_option in stat:
+            if cnt == 7:  # skip access time
+                continue
+            cnt += 1
+            hashed_str += ";" + str(stat_option)
+        hashed_str += ";" + str(os.path.getmtime(self.f_path))
+        return hashed_str
+    
+    @property
+    def data_length(self): 
+        return os.path.getsize(self.f_path)
+    
+    
+class HttpOpener(object):
+    '''
+    downloads small files
+    for large files returns wrapped http stream
+    '''
+    
+    def __init__(self, url):
+        self.url = url
+        # Meta params
+        self.gzip = False
+        self.data_info = requests.head(self.url, verify=False)
+        
+    def __call__(self, *args, **kwargs):
+        return self.open(*args, **kwargs)
+    
+    def open(self, *args, **kwargs):
+        if self.data_info.status_code == 200:
+            self._detect_gzip()
+            if not self.gzip \
+            and not self.data_length or not str(self.data_length).isdigit() or int(self.data_length) > 10**8):
+	            logging.info("Ammofile data is larger than 100MB. Reading from stream..")
+                return HttpStreamWrapper(self.url)
+            else:
+                hasher = hashlib.md5()
+                hasher.update(self.hash)
+                tmpfile_path = "/tmp/%s" % hasher.hexdigest()
+                if os.path.exists(tmpfile_path):
+		            logging.info("Ammofile has already been downloaded to %s . Using it..", tmpfile_path)
+		        else:
+		            logging.info("Downloading ammofile to %s", tmpfile_path)
+                    data = requests.get(self.url)
+                    f = open(tmpfile_path, "wb")
+                    f.write(data.content)
+                    f.close()
+                if self.gzip:
+                    return gzip.open(tmpfile_path, mode='rb')
+                else:
+                    return open(tmpfile_path, 'rb')
+        else:
+            raise RuntimeError(
+	        "Ammo file not found: %s %s" % (self.data_info.status_code, self.url))
+
+    def _detect_gzip(self):
+        stream = requests.get(self.url, stream=True, verify=False)
+        if stream.status_code == 200:
+            try:
+                stream_iterator = stream.raw.stream(2, decode_content=True)
+                gz_header = stream_iterator.next()
+                if gz_header[:2] == b'\037\213':
+		            logging.info("Ammofile data is in gz format")
+                    self.gzip = True
+            except:
+                logging.exception("")
+	        finally:
+	            stream.connection.close()
+    
+    @property
+    def hash(self):
+        last_modified = self.data_info.headers.get("Last-Modified", '')
+        return self.url + "|" + last_modified 
+    
+    @property
+    def data_length(self): 
+    	try:
+    	    data_length = int(self.data_info.headers.get("Content-Length", 0))
+    	except:
+    	    data_length = 0
+        return data_length
+    
+    
+class HttpStreamWrapper():
+    '''
+    makes http stream to look like file object
+    '''
+    
+    def __init__(self, url):
+        self.url = url
+        self.buffer = ''
+        self.pointer = 0
+        self.stream = requests.get(self.url, stream=True, verify=False)
+        self._content_consumed = False
+        
+    def __enter__(self):
+        return self
+        
+    def __exit__(self, *args):
+        self.stream.connection.close()
+        
+    def __iter__(self):
+        while True:
+            yield self.next()
+            
+    def _reopen_stream(self):
+        self.stream.connection.close()
+        self.stream = requests.get(self.url, stream=True, verify=False)
+        self._content_consumed = False
+        
+    def _enhance_buffer(self, bytes=10**3):
+        self.buffer += self.stream.iter_content(bytes).next()
+        
+    def tell(self):
+        return self.pointer
+    
+    def seek(self, position):
+        if self.pointer:
+            self.buffer = ''
+            self._reopen_stream()
+            self._enhance_buffer()
+            while len(self.buffer) < position:
+                self._enhance_buffer()
+            self.pointer = position
+            self.buffer = self.buffer[position:]
+        
+    def next(self):
+        while not '\n' in self.buffer:
+            try:
+                self._enhance_buffer()
+            except (StopIteration, TypeError, requests.exceptions.StreamConsumedError):
+                self._content_consumed = True
+		        break
+        if not self._content_consumed or self.buffer:
+    	    try:
+                    line = self.buffer[:self.buffer.index('\n')+1]
+    	    except ValueError:
+        		line = self.buffer
+            self.pointer += len(line)
+            self.buffer = self.buffer[len(line):]
+            return line
+        raise StopIteration
+        
+            
+    def read(self, chunk_size):
+        while len(self.buffer) < chunk_size:
+            try:
+                self._enhance_buffer()
+            except (StopIteration, TypeError, requests.exceptions.StreamConsumedError):
+                break
+        if len(self.buffer) > chunk_size:
+            chunk = self.buffer[:chunk_size]
+        else:
+            chunk = self.buffer
+        self.pointer += len(chunk)
+        self.buffer = self.buffer[len(chunk):]
+        return chunk
+    
+    def readline(self):
+        '''
+        requests iter_lines() uses splitlines() thus losing '\r\n' 
+        we need a different behavior for AmmoFileReader
+        and we have to use our buffer because we have probably read a bunch into it already
+        '''
+        try:
+            return self.next()
+        except StopIteration:
+            return ''
+

--- a/yandextank/stepper/util.py
+++ b/yandextank/stepper/util.py
@@ -154,7 +154,7 @@ class HttpOpener(object):
         if self.data_info.status_code == 200:
             self._detect_gzip()
             if not self.gzip \
-            and not self.data_length or not str(self.data_length).isdigit() or int(self.data_length) > 10**8):
+            and (not self.data_length or not str(self.data_length).isdigit() or int(self.data_length) > 10**8):
                 logging.info("Ammofile data is larger than 100MB. Reading from stream..")
                 return HttpStreamWrapper(self.url)
             else:

--- a/yandextank/stepper/util.py
+++ b/yandextank/stepper/util.py
@@ -155,16 +155,16 @@ class HttpOpener(object):
             self._detect_gzip()
             if not self.gzip \
             and not self.data_length or not str(self.data_length).isdigit() or int(self.data_length) > 10**8):
-	            logging.info("Ammofile data is larger than 100MB. Reading from stream..")
+            	logging.info("Ammofile data is larger than 100MB. Reading from stream..")
                 return HttpStreamWrapper(self.url)
             else:
                 hasher = hashlib.md5()
                 hasher.update(self.hash)
                 tmpfile_path = "/tmp/%s" % hasher.hexdigest()
                 if os.path.exists(tmpfile_path):
-		            logging.info("Ammofile has already been downloaded to %s . Using it..", tmpfile_path)
-		        else:
-		            logging.info("Downloading ammofile to %s", tmpfile_path)
+					logging.info("Ammofile has already been downloaded to %s . Using it..", tmpfile_path)
+				else:
+					logging.info("Downloading ammofile to %s", tmpfile_path)
                     data = requests.get(self.url)
                     f = open(tmpfile_path, "wb")
                     f.write(data.content)
@@ -184,12 +184,12 @@ class HttpOpener(object):
                 stream_iterator = stream.raw.stream(2, decode_content=True)
                 gz_header = stream_iterator.next()
                 if gz_header[:2] == b'\037\213':
-		            logging.info("Ammofile data is in gz format")
+					logging.info("Ammofile data is in gz format")
                     self.gzip = True
             except:
                 logging.exception("")
-	        finally:
-	            stream.connection.close()
+			finally:
+				stream.connection.close()
     
     @property
     def hash(self):
@@ -198,10 +198,10 @@ class HttpOpener(object):
     
     @property
     def data_length(self): 
-    	try:
-    	    data_length = int(self.data_info.headers.get("Content-Length", 0))
-    	except:
-    	    data_length = 0
+		try:
+			data_length = int(self.data_info.headers.get("Content-Length", 0))
+		except:
+			data_length = 0
         return data_length
     
     


### PR DESCRIPTION
for ammofiles
http_opener provides wrapped http stream if ammofile data is larger than 100MB (probably a temporary heuristics) 
if less, downloads it to /tmp/.. and opens it with regular file opener (open() \ gzip.open())
if data is gzipped downloads it anyway

gzip.open() and open() are also wrapped within an object, so we can access such properties as data_length and hash the same way we do for any opener.

Thus, user can use an http storage by setting an url, i.e.: "phantom.ammofile=https ://smthng.com/ammo-shmammo"