### PR TITLE
Fixing log collection for monitoring plugin and StepperWrapper.

### DIFF
--- a/yandextank/plugins/Monitoring/plugin.py
+++ b/yandextank/plugins/Monitoring/plugin.py
@@ -105,7 +105,7 @@ class MonitoringPlugin(AbstractPlugin):
             logger.info("Monitoring has been disabled")
         else:
             logger.info("Starting monitoring with config: %s", self.config)
-            self.core.add_artifact_file(self.config, True)
+            self.core.add_artifact_file(self.config)
             self.monitoring.config = self.config
             if self.default_target:
                 self.monitoring.default_target = self.default_target

--- a/yandextank/stepper/main.py
+++ b/yandextank/stepper/main.py
@@ -204,7 +204,7 @@ class StepperWrapper(object):
             self.log.info("Using specified stpd-file: %s", self.stpd)
             stepper_info = publish_info(self.__read_cached_options())
         self.core.add_artifact_file(self.stpd)
-        self.core.add_artifact_file(self.__si_filename(self.stpd))
+        self.core.add_artifact_file(self.__si_filename())
         self.ammo_count = stepper_info.ammo_count
         self.duration = stepper_info.duration
         self.loop_count = stepper_info.loop_count

--- a/yandextank/stepper/main.py
+++ b/yandextank/stepper/main.py
@@ -204,6 +204,7 @@ class StepperWrapper(object):
             self.log.info("Using specified stpd-file: %s", self.stpd)
             stepper_info = publish_info(self.__read_cached_options())
         self.core.add_artifact_file(self.stpd)
+        self.core.add_artifact_file(self.__si_filename(self.stpd))
         self.ammo_count = stepper_info.ammo_count
         self.duration = stepper_info.duration
         self.loop_count = stepper_info.loop_count

--- a/yandextank/stepper/main.py
+++ b/yandextank/stepper/main.py
@@ -203,6 +203,7 @@ class StepperWrapper(object):
         else:
             self.log.info("Using specified stpd-file: %s", self.stpd)
             stepper_info = publish_info(self.__read_cached_options())
+        self.core.add_artifact_file(self.stpd)
         self.ammo_count = stepper_info.ammo_count
         self.duration = stepper_info.duration
         self.loop_count = stepper_info.loop_count


### PR DESCRIPTION
Monitoring plugin stores configs files like `monitoring_default_*.xml` in current working directory, and so does StepperWrapper with `access.log_*.stpd` and `access.log_*.stpd_si.json` files. 