### PR TITLE
bugfix for previous pull 163

### DIFF
--- a/yandextank/plugins/Monitoring/collector.py
+++ b/yandextank/plugins/Monitoring/collector.py
@@ -542,7 +542,7 @@ class MonitoringCollector:
                         filtered = self.filtering(filter_mask, keys)
                         if filtered:
                             out = filtered + '\n'  # filtering values
-                except:
+                except IndexError:
                     pass
         return out
 

--- a/yandextank/plugins/Monitoring/plugin.py
+++ b/yandextank/plugins/Monitoring/plugin.py
@@ -42,8 +42,9 @@ class MonitoringPlugin(AbstractPlugin):
         return __file__
 
     def start_test(self):
-        self.monitoring.load_start_time = time.time()
-        logger.debug("load_start_time = %s" % self.monitoring.load_start_time)
+        if self.monitoring:
+            self.monitoring.load_start_time = time.time()
+            logger.debug("load_start_time = %s" % self.monitoring.load_start_time)
 
     def get_available_options(self):
         return ["config", "default_target", 'ssh_timeout']


### PR DESCRIPTION
if there are no access to targets or monitoring.config=none, then self.monitoring in MonitoringPlugin doesn't exist and that causes exception            
"self.monitoring.load_start_time = time.time()"