### PR TITLE
requests.head omits Content-Length 

### DIFF
--- a/yandextank/stepper/util.py
+++ b/yandextank/stepper/util.py
@@ -150,7 +150,7 @@ class HttpOpener(object):
         self.url = url
         # Meta params
         self.gzip = False
-        self.data_info = requests.head(self.url, verify=False, allow_redirects=True)
+        self.data_info = requests.head(self.url, verify=False, allow_redirects=True, headers={'Accept-Encoding': 'identity'})
 
     def __call__(self, *args, **kwargs):
         return self.open(*args, **kwargs)


### PR DESCRIPTION
requests.head omits Content-Length and therefore yandex-tank cannot determine the ammofile size and always streams it.
Fix was found in https://github.com/kennethreitz/requests/issues/2731:
"Requests library specifies gzip, deflate as acceptable encodings by default and urllib2 specifies identity by default."