### PR TITLE
deleted mentions of yandex-tank-* binaries from docs and rpm spec file

### DIFF
--- a/data/yandex-tank.spec
+++ b/data/yandex-tank.spec
@@ -35,11 +35,7 @@ cp -arp Tank %{buildroot}/%{_libdir}/yandex-tank/
 cp -ap tankcore.py %{buildroot}/%{_libdir}/yandex-tank/
 cp -ap tank.py %{buildroot}/%{_libdir}/yandex-tank/
 cp -ap *.sh %{buildroot}/%{_libdir}/yandex-tank/
-ln -s %{_libdir}/yandex-tank/lunapark %{buildroot}/%{_bindir}/lunapark
 ln -s %{_libdir}/yandex-tank/tank.py %{buildroot}/%{_bindir}/yandex-tank
-ln -s %{_libdir}/yandex-tank/ab.sh %{buildroot}/%{_bindir}/yandex-tank-ab
-ln -s %{_libdir}/yandex-tank/jmeter.sh %{buildroot}/%{_bindir}/yandex-tank-jmeter
-ln -s %{_libdir}/yandex-tank/bfg.sh %{buildroot}/%{_bindir}/yandex-tank-bfg
 
 %clean
 rm -rf %{buildroot}
@@ -50,9 +46,6 @@ rm -rf %{buildroot}
 %{_sysconfdir}/bash_completion.d/yandex-tank.completion
 %{_bindir}/lunapark
 %{_bindir}/yandex-tank
-%{_bindir}/yandex-tank-ab
-%{_bindir}/yandex-tank-jmeter
-%{_bindir}/yandex-tank-bfg
 %{_libdir}/yandex-tank
 
 %changelog

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -4,11 +4,8 @@ Advanced usage
 Command line options
 ~~~~~~~~~~~~~~~~~~~~
 
-There are three executables in Yandex.Tank package: ``yandex-tank``,
-``yandex-tank-ab`` and ``yandex-tank-jmeter``. Last two of them just use
-different kind of load generation utilities, ``ab`` (Apache Benchmark) and
-``jmeter`` (Apache JMeter), accordingly. Command line options are common
-for all three.
+Yandex.Tank has an obviously named executable ``yandex-tank``. 
+Here are available command line options: 
 
 - **-h, --help** - show command line options 
 - **-c CONFIG, --config=CONFIG** - read options from INI file. It is possible to set multiple INI files by specifying the option serveral times. Default: ``./load.ini`` 


### PR DESCRIPTION
they are obsolete now