### PR TITLE
Fix agent hanging on broken ssh connection

### DIFF
--- a/yandextank/plugins/Monitoring/agent/agent.py
+++ b/yandextank/plugins/Monitoring/agent/agent.py
@@ -608,6 +608,12 @@ class AgentWorker(Thread):
                 logger.debug("str: %s" % row)
                 sys.stdout.write(row + '\n')
                 sys.stdout.flush()
+            except IOError, e:
+                if e.errno==32:
+                    logger.error("Broken pipe, can't send data back, terminating")
+                    self.finished = True
+                else:
+                    logger.error('IOError while converting line: %s: %s', line, e)
             except Exception, e:
                 logger.error('Failed to convert line %s: %s', line, e)
 


### PR DESCRIPTION
Not sure how to handle IOError other than broken pipe (errno 32), so just log it and continue.