### PR TITLE
Fix: more consistent final step for step(...) schedule

### DIFF
--- a/yandextank/stepper/load_plan.py
+++ b/yandextank/stepper/load_plan.py
@@ -135,8 +135,12 @@ class Stairway(Composite):
             Const(minrps + i * increment, duration)
             for i in xrange(0, n_steps + 1)
         ]
-        if (n_steps + 1) * increment < maxrps:
-            steps.append(Const(maxrps, duration))
+        if increment > 0:
+            if (min_rps + n_steps * increment) < maxrps:
+                steps.append(Const(maxrps, duration))
+        elif increment < 0:
+            if (min_rps + n_steps * increment) > maxrps:
+                steps.append(Const(maxrps, duration))
         logging.info(steps)
         super(Stairway, self).__init__(steps)
 


### PR DESCRIPTION
Stepper tries to add final step if maxrps is not achieved with usual increment size, i.e. (maxrps-minrps) can not be diveded by step without reminder, but previous version
1) does not start calculation for final step from minrps (so it can add excessive step with maxrps when it matches step size)
2) does not handle decreasing rps the same way