### PR TITLE
 Fix markup once again

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -210,7 +210,7 @@ there.
 Sources
 ================
 
-Yandex.Tank sources ((https://github.com/yandex/yandex-tank here)).
+Yandex.Tank sources are `here <https://github.com/yandex-load/yandex-tank>`_.
 
 load.ini example
 ================


### PR DESCRIPTION
Commit 1f3fa555e31e76656eea608cd222e31252392670 was lost during refactoring. Fixing markup once again :)