### PR TITLE
add net.netfilter.nf_conntrack_max = 1048576 to docs

### DIFF
--- a/docs/generator_tuning.rst
+++ b/docs/generator_tuning.rst
@@ -87,3 +87,4 @@ system limits:
     net.ipv4.tcp_fin_timeout = 10
     net.ipv4.tcp_low_latency = 1
     net.ipv4.tcp_syncookies = 0
+    net.netfilter.nf_conntrack_max = 1048576


### PR DESCRIPTION
As discussed in Gitter chat, iptables can interfere with tank operation. Specifically, nf_conntrack component table can overflow, which results in these messages from kernel:

nf_conntrack: table full, dropping packet

In this case, amount of connections in SYN_SENT state rapidly increases, and requests to target start to fail.

Increasing net.netfilter.nf_conntrack_max to 1048576 solves this problem.