### PR TITLE
Jmeter improvements

### DIFF
--- a/docs/core_and_modules.rst
+++ b/docs/core_and_modules.rst
@@ -426,11 +426,25 @@ Options
 :buffered_seconds:
   Amount of seconds to which delay aggregator, to be sure that everything were read from jmeter's results file.
 
-:connect_time:
-  It sets jmeter.save.saveservice.connect_time=false if the value is '0' or empty string, jmeter.save.saveservice.connect_time=true in any other cases, empty string by default.
+:jmeter_ver:
+  Which jmeter version tank should expect. Currently it affects the way connection time is logged, but may be used for other version-specific settings.
+
+  Default: ``3.0``
+
+:ext_log:
+  Available options: ``none``, ``errors``, ``all``. Add one more simple data writer which logs all possible fields in jmeter xml format, this log is saved in test dir as ``jmeter_ext_XXXX.jtl``.
+
+  Default: ``none``
 
 :all other options in the section:
   They will be passed as User Defined Variables to JMeter.
+
+Timing calculation issues
+-----------------------
+
+Since version 2.13 jmeter could measure connection time, latency and full request time (aka <interval_real> in phantom), but do it in it's own uniq way: latency include connection time but not recieve time. For the sake of consistency we recalculate <latency> as <latency - connect_time> and calculate <recieve_time> as <interval_real - latency - connect_time>>, but it does not guranteed to work perfectly in all cases (i.e. some samplers may not support latency and connect_time and you may get something strange in case of timeouts).
+
+For jmeter 2.12 and older connection time logging not avaliable, set ``jmeter_ver`` properly or you'll get an error for unknown field in Simlpe Data Writer listner added by tank.
 
 Artifacts
 ---------

--- a/yandextank/plugins/JMeter/config/jmeter_writer_ext.xml
+++ b/yandextank/plugins/JMeter/config/jmeter_writer_ext.xml
@@ -35,6 +35,45 @@
     <stringProp name="TestPlan.comments">Added automatically</stringProp>
 </ResultCollector>
 <hashTree/>
+<ResultCollector guiclass="SimpleDataWriter" testclass="ResultCollector" testname="Yandex.Tank debug logger" enabled="true">
+    <boolProp name="ResultCollector.error_logging">%(ext_level)s</boolProp>
+    <objProp>
+        <name>saveConfig</name>
+        <value class="SampleSaveConfiguration">
+            <time>true</time>
+            <latency>true</latency>
+            <timestamp>true</timestamp>
+            <success>true</success>
+            <label>true</label>
+            <code>true</code>
+            <message>true</message>
+            <threadName>true</threadName>
+            <dataType>true</dataType>
+            <encoding>true</encoding>
+            <assertions>true</assertions>
+            <subresults>true</subresults>
+            <responseData>true</responseData>
+            <samplerData>true</samplerData>
+            <xml>true</xml>
+            <fieldNames>true</fieldNames>
+            <responseHeaders>true</responseHeaders>
+            <requestHeaders>true</requestHeaders>
+            <responseDataOnError>false</responseDataOnError>
+            <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+            <assertionsResultsToSave>0</assertionsResultsToSave>
+            <bytes>true</bytes>
+            <url>true</url>
+            <hostname>true</hostname>
+            <threadCounts>true</threadCounts>
+            <sampleCount>true</sampleCount>
+            <idleTime>true</idleTime>
+            %(save_connect)s
+        </value>
+    </objProp>
+<stringProp name="filename">%(ext_log)s</stringProp>
+<stringProp name="TestPlan.comments">Added automatically</stringProp>
+</ResultCollector>
+<hashTree/>
 <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="Yandex.Tank Variables" enabled="true">
 <collectionProp name="Arguments.arguments">
     %(udv)s

--- a/yandextank/plugins/JMeter/reader.py
+++ b/yandextank/plugins/JMeter/reader.py
@@ -94,6 +94,16 @@ jtl_types = {
     'connect_time': np.float64,
 }
 
+def fix_latency(row):
+    if row['latency'] < row['connect_time']:
+        if row['interval_real'] < row['connect_time']:
+            latency = 0
+        else:
+            latency = row['interval_real'] - row['connect_time']
+    else:
+        latency = row['latency'] - row['connect_time']
+    return latency
+
 
 # timeStamp,elapsed,label,responseCode,success,bytes,grpThreads,allThreads,Latency
 def string_to_df(data):
@@ -107,9 +117,11 @@ def string_to_df(data):
     chunk['interval_real'] = chunk["interval_real"] * 1000  # convert to µs
     chunk.set_index(['receive_sec'], inplace=True)
     l = len(chunk)
-    chunk['connect_time'] = chunk['connect_time'].fillna(0).astype(np.int64)
+    chunk['connect_time'] = (chunk['connect_time'].fillna(0) * 1000).astype(np.int64)
+    chunk['latency'] = chunk['latency'] * 1000
+    chunk['latency'] = chunk.apply(fix_latency, axis=1)
     chunk['send_time'] = np.zeros(l)
-    chunk['receive_time'] = np.zeros(l)
+    chunk['receive_time'] = chunk['interval_real'] - chunk['latency'] - chunk['connect_time']
     chunk['interval_event'] = np.zeros(l)
     chunk['size_out'] = np.zeros(l)
     chunk['net_code'] = exc_to_net(chunk['retcode'], chunk['success'])
@@ -138,6 +150,8 @@ class JMeterReader(object):
         self.buffer = ""
         self.stat_buffer = ""
         self.jtl_file = filename
+        self.jmeter_finished = False
+        self.agg_finished = False
         self.closed = False
         self.stat_queue = q.Queue()
         self.stats_reader = JMeterStatAggregator(TimeChopper(
@@ -166,6 +180,8 @@ class JMeterReader(object):
             else:
                 self.buffer += parts[0]
         else:
+            if self.jmeter_finished:
+                self.agg_finished = True
             jtl.readline()
         return None
 


### PR DESCRIPTION
   - Wait until jtl fully processed if jmeter exit normally
   - Optional extended xml logging (errors/all)
   - More logical measurement of latency, connect_time, recieve_time (for 2.13+)
   - Documentation update