### PR TITLE
check enviroment for https_proxy

### DIFF
--- a/yandextank/plugins/Overload/client.py
+++ b/yandextank/plugins/Overload/client.py
@@ -19,6 +19,11 @@ class OverloadClient(object):
         self.session = requests.Session()
         self.session.verify = False
         self.session.headers.update({"User-Agent": "tank"})
+        if "https" in requests.utils.getproxies():
+           logger.info("Connecting via proxy %s" % requests.utils.getproxies()['https'])
+           self.session.proxies = requests.utils.getproxies()
+        else:
+           logger.info("Proxy not set")
 
     def set_api_address(self, addr):
         self.address = addr

--- a/yandextank/plugins/Overload/client.py
+++ b/yandextank/plugins/Overload/client.py
@@ -20,10 +20,10 @@ class OverloadClient(object):
         self.session.verify = False
         self.session.headers.update({"User-Agent": "tank"})
         if "https" in requests.utils.getproxies():
-           logger.info("Connecting via proxy %s" % requests.utils.getproxies()['https'])
-           self.session.proxies = requests.utils.getproxies()
+            logger.info("Connecting via proxy %s" % requests.utils.getproxies()['https'])
+            self.session.proxies = requests.utils.getproxies()
         else:
-           logger.info("Proxy not set")
+            logger.info("Proxy not set")
 
     def set_api_address(self, addr):
         self.address = addr


### PR DESCRIPTION
Fixed #307
Now Overload plugin can send data over https proxy 
Variable https_proxy should be specified at /etc/enviroment or via export https_proxy
