### PR TITLE
os.getlogin() should be avoided

### DIFF
--- a/yandextank/common/util.py
+++ b/yandextank/common/util.py
@@ -2,6 +2,7 @@
 Common utilities
 '''
 import os
+import pwd
 import socket
 import threading as th
 import traceback
@@ -139,7 +140,7 @@ def check_ssh_connection():
         '-e', '--endpoint', default='example.org', help='which host to try')
 
     parser.add_argument(
-        '-u', '--username', default=os.getlogin(), help='SSH username')
+        '-u', '--username', default=pwd.getpwuid(os.getuid())[0], help='SSH username')
 
     parser.add_argument('-p', '--port', default=22, type=int, help='SSH port')
     args = parser.parse_args()


### PR DESCRIPTION
had the famous error "os.getlogin OSError: [Errno 2] No such file or directory" http://bugs.python.org/issue1750013
Even python docs recommend to avoid this function - https://docs.python.org/2.7/library/os.html?highlight=os.getlogin#process-parameters
also look at https://linux.die.net/man/3/getlogin, section Bugs