### PR TITLE
Gevent-based BFG worker

### DIFF
--- a/docs/core_and_modules.rst
+++ b/docs/core_and_modules.rst
@@ -579,6 +579,24 @@ How it works
 
 .. image:: ./pic/tank-bfg.png
 
+BFG Worker Type
+-----------
+By default, BFG will create lots of processes (number is defined by ``instances`` option).
+Every process will execute requests in a single thread. These processes will comsume a lot of memory.
+It's also possible to switch this behavior and use ``gevent`` to power up every worker process,
+allowing it to have multiple concurrent threads executing HTTP requests.
+
+With green worker, it's recommended to set ``instances`` to number of CPU cores,
+and adjust the number of real threads by ``green_threads_per_instance`` option.
+
+INI file section: **[bfg]**
+
+:worker_type:
+  Set it to ``green`` to let every process have multiple concurrent green threads.
+
+:green_threads_per_instance:
+  Number of green threads every worker process will execute. Only affects ``green`` worker type.
+
 BFG Options
 -----------
 

--- a/yandextank/core/tankcore.py
+++ b/yandextank/core/tankcore.py
@@ -152,6 +152,7 @@ class TankCore(object):
         self.taskset_affinity = self.get_option(self.SECTION, 'affinity', '')
 
         options = self.config.get_options(self.SECTION, self.PLUGIN_PREFIX)
+
         for (plugin_name, plugin) in options:
             plugin_path, config_section = parse_plugin(plugin)
             if not plugin_path:

--- a/yandextank/plugins/Bfg/plugin.py
+++ b/yandextank/plugins/Bfg/plugin.py
@@ -7,7 +7,7 @@ from ...common.interfaces import AbstractPlugin, GeneratorPlugin
 from .guns import LogGun, SqlGun, CustomGun, HttpGun, ScenarioGun, UltimateGun
 from .reader import BfgReader, BfgStatsReader
 from .widgets import BfgInfoWidget
-from .worker import BFG
+from .worker import BFGMultiprocessing, BFGGreen
 from ..Aggregator import Plugin as AggregatorPlugin
 from ..Console import Plugin as ConsolePlugin
 from ...stepper import StepperWrapper
@@ -69,11 +69,19 @@ class Plugin(AbstractPlugin, GeneratorPlugin):
             cached_stpd = True
         else:
             cached_stpd = False
+
+        if self.get_option("worker_type", "") == "green":
+            BFG = BFGGreen
+        else:
+            BFG = BFGMultiprocessing
+
         self.bfg = BFG(
             gun=self.gun,
             instances=self.stepper_wrapper.instances,
             stpd_filename=self.stepper_wrapper.stpd,
-            cached_stpd=cached_stpd)
+            cached_stpd=cached_stpd,
+            green_threads_per_instance=int(self.get_option('green_threads_per_instance', 1000)),
+        )
         aggregator = None
         try:
             aggregator = self.core.get_plugin_of_type(AggregatorPlugin)


### PR DESCRIPTION
What this patch lets you to do:
New BFG option `worker_type`. If it's `green`, the new worker will be used instead of the existing purely multiprocessing one. This worker spawns `bfg.instances` worker processes, but this number should be kept law (eg. number of CPU cores). Every worker process will spawn `bfg.green_threads_per_instance` greenlets, which effectively do just the same as workers in the current implementation: wait for tasks and execute.

I've made a simple tests runner, which uses ultimate BFG with urllib3 requests inside. Here are two test result. I also have `telegraf` client on my machine (which runs the Yandex.Tank), so you can look at Memory, CPU, context switches, interrupts and other stuff happening on my machine while executing tests.
1) Original worker, 1200 instances https://overload.yandex.net/10486
2) Green worker, 4 instances, 300 greenlets per instance https://overload.yandex.net/10484

As you can see, green worker consumes significantly less memory (~100Mb vs. ~10Gb). Also result on the old workere are very unstable at the beginning, as it takes much time to start all the processes, it consumes CPU and affects existing workers.
And I can't use more than 1500 instances with old worker, as it eats all RAM, hits swap heavily and my machine dies slowly :) With green worker I tried 10k greenlets - no problems detected.


If somebody finds this PR useful and candidate to be merged - I'll update documentation and some other stuff in this PR.