### PR TITLE
Jmeter termination #327

### DIFF
--- a/yandextank/plugins/JMeter/plugin.py
+++ b/yandextank/plugins/JMeter/plugin.py
@@ -157,7 +157,7 @@ class Plugin(AbstractPlugin, GeneratorPlugin):
                 "Terminating jmeter process group with PID %s",
                 self.jmeter_process.pid)
             try:
-                os.killpg(self.jmeter_process.pid, signal.SIGTERM)
+                os.killpg(self.jmeter_process.pid, signal.SIGKILL)
             except OSError as exc:
                 logger.debug("Seems JMeter exited itself: %s", exc)
                 # Utils.log_stdout_stderr(logger, self.jmeter_process.stdout, self.jmeter_process.stderr, "jmeter")


### PR DESCRIPTION
There are problems when tank was sending SIGTERM signal to the Jmeter. I changed it to SIGKILL.