### PR TITLE
Add failover for benchmark plugin

### DIFF
--- a/yandextank/plugins/JMeter/plugin.py
+++ b/yandextank/plugins/JMeter/plugin.py
@@ -22,8 +22,8 @@ class Plugin(AbstractPlugin, GeneratorPlugin):
     """ JMeter tank plugin """
     SECTION = 'jmeter'
 
-    def __init__(self, core, cfg, cfg_updater):
-        AbstractPlugin.__init__(self, core, cfg, cfg_updater)
+    def __init__(self, core, config_section):
+        AbstractPlugin.__init__(self, core, config_section)
         self.jmeter_process = None
         self.args = None
         self.original_jmx = None
@@ -55,20 +55,25 @@ class Plugin(AbstractPlugin, GeneratorPlugin):
         self.jtl_file = self.core.mkstemp('.jtl', 'jmeter_')
         self.core.add_artifact_file(self.jtl_file)
         self.user_args = self.get_option("args", '')
-        self.jmeter_path = self.get_option('jmeter_path')
+        self.jmeter_path = self.get_option('jmeter_path', 'jmeter')
         self.jmeter_log = self.core.mkstemp('.log', 'jmeter_')
-        self.jmeter_ver = self.get_option('jmeter_ver')
-        self.ext_log = self.get_option('extended_log', self.get_option('ext_log'))
-
+        self.jmeter_ver = float(self.get_option('jmeter_ver', '3.0'))
+        self.ext_log = self.get_option(
+            'extended_log', self.get_option('ext_log', 'none'))
+        if self.ext_log not in self.ext_levels:
+            self.ext_log = 'none'
         if self.ext_log != 'none':
             self.ext_log_file = self.core.mkstemp('.jtl', 'jmeter_ext_')
             self.core.add_artifact_file(self.ext_log_file)
-
-        self.jmeter_buffer_size = self.get_option('buffer_size', self.get_option('buffered_seconds', '3'))
+        self.jmeter_buffer_size = int(
+            self.get_option(
+                'buffer_size', self.get_option('buffered_seconds', '3')))
         self.core.add_artifact_file(self.jmeter_log, True)
-        self.exclude_markers = set(self.get_option('exclude_markers', []))
+        self.exclude_markers = set(
+            filter((lambda marker: marker != ''),
+                   self.get_option('exclude_markers', []).split(' ')))
         self.jmx = self.__add_jmeter_components(
-            self.original_jmx, self.jtl_file, self.get_option('variables'))
+            self.original_jmx, self.jtl_file, self._get_variables())
         self.core.add_artifact_file(self.jmx)
 
         jmeter_stderr_file = self.core.mkstemp(".log", "jmeter_stdout_stderr_")
@@ -168,9 +173,17 @@ class Plugin(AbstractPlugin, GeneratorPlugin):
             source_lines = src_jmx.readlines()
 
         try:
+            # In new Jmeter version (3.2 as example) WorkBench's plugin checkbox enabled by default
+            # It totally crashes Yandex tank injection and raises XML Parse Exception
             closing = source_lines.pop(-1)
-            closing = source_lines.pop(-1) + closing
-            closing = source_lines.pop(-1) + closing
+            if "WorkBenchGui" in source_lines[-5]:
+                logger.info("WorkBench checkbox enabled...bypassing")
+                last_string_count = 6
+            else:
+                last_string_count = 2
+            while last_string_count > 0:
+                closing = source_lines.pop(-1) + closing
+                last_string_count -= 1
             logger.debug("Closing statement: %s", closing)
         except Exception as exc:
             raise RuntimeError("Failed to find the end of JMX XML: %s" % exc)
@@ -218,6 +231,14 @@ class Plugin(AbstractPlugin, GeneratorPlugin):
             fh.write(tpl % tpl_args)
             fh.write(closing)
         return new_jmx
+
+    def _get_variables(self):
+        res = {}
+        for option in self.core.config.get_options(self.SECTION):
+            if option[0] not in self.get_available_options():
+                res[option[0]] = option[1]
+        logging.debug("Variables: %s", res)
+        return res
 
 
 class JMeterInfoWidget(AbstractInfoWidget, AggregateResultListener):

--- a/yandextank/plugins/JMeter/plugin.py
+++ b/yandextank/plugins/JMeter/plugin.py
@@ -168,9 +168,17 @@ class Plugin(AbstractPlugin, GeneratorPlugin):
             source_lines = src_jmx.readlines()
 
         try:
+            # In new Jmeter version (3.2 as example) WorkBench's plugin checkbox enabled by default
+            # It totally crashes Yandex tank injection and raises XML Parse Exception
             closing = source_lines.pop(-1)
-            closing = source_lines.pop(-1) + closing
-            closing = source_lines.pop(-1) + closing
+            if "WorkBenchGui" in source_lines[-5]:
+                logger.info("WorkBench checkbox enabled...bypassing")
+                last_string_count = 6
+            else:
+                last_string_count = 2
+            while last_string_count > 0:
+                closing = source_lines.pop(-1) + closing
+                last_string_count -= 1
             logger.debug("Closing statement: %s", closing)
         except Exception as exc:
             raise RuntimeError("Failed to find the end of JMX XML: %s" % exc)


### PR DESCRIPTION
The usual XML footer looks like: 
```
           </doubleProp>
          </ConstantThroughputTimer>
          <hashTree/>
        </hashTree>
      </hashTree>
    </hashTree>
  </hashTree>
</jmeterTestPlan>
```
... the lastest Jmeter versions have default XML like:
```
      </hashTree>
    </hashTree>
    <WorkBench guiclass="WorkBenchGui" testclass="WorkBench" testname="WorkBench" enabled="true">
      <boolProp name="WorkBench.save">true</boolProp>
    </WorkBench>
    <hashTree/>
  </hashTree>
</jmeterTestPlan>
```
YandexTank injection brakes XML formating:

`Problem loading XML from:'/root/****/modified_e9bH1J.jmx', missing class com.thoughtworks.xstream.converters.ConversionException: `

So additional "if else" solves the problem.
