### PR TITLE
InfluxPlugin: fix field type conflict

### DIFF
--- a/yandextank/plugins/Influx/config/schema.yaml
+++ b/yandextank/plugins/Influx/config/schema.yaml
@@ -7,6 +7,15 @@ address:
 port:
   default: 8086
   type: integer
+database:
+  default: mydb
+  type: string
+username:
+  default: root
+  type: string
+password:
+  default: root
+  type: string
 grafana_root:
   default: "http://localhost/"
   type: string

--- a/yandextank/plugins/Influx/decoder.py
+++ b/yandextank/plugins/Influx/decoder.py
@@ -69,7 +69,7 @@ class Decoder(object):
                 "fields": {
                     "active_threads": stat["metrics"]["instances"],
                     "RPS": data["overall"]["interval_real"]["len"],
-                    "planned_requests": stat["metrics"]["reqps"],
+                    "planned_requests": float(stat["metrics"]["reqps"]),
                 },
             }, {
                 "measurement": "net_codes",

--- a/yandextank/plugins/Influx/plugin.py
+++ b/yandextank/plugins/Influx/plugin.py
@@ -41,7 +41,12 @@ class Plugin(AbstractPlugin, AggregateResultListener,
         address = self.get_option("address")
         port = self.get_option("port")
         self.client = InfluxDBClient(
-            address, port, 'root', 'root', 'mydb')
+            address,
+            port,
+            username=self.get_option("username"),
+            password=self.get_option("password"),
+            database=self.get_option("database"),
+        )
         grafana_root = self.get_option("grafana_root")
         grafana_dashboard = self.get_option("grafana_dashboard")
         uuid = str(uuid4())


### PR DESCRIPTION
I have tried a plugin with influxdb v1.4.2 and got `field type conflict` error. It happens when I have `const` and then `line` schedule. Former posts `planned_requests` (`stat["metrics"]["reqps"]`) as `int` and latter as `float`. It causes mentioned error.

As a fix, casting the value to float ensures that `planned_requests` always has the same influxdb type. If you think we can use `int` instead, I would rather go for it. Otherwise, float shall suit both cases. 

This is an excerpt from traceback:
```
  File "/usr/local/lib/python2.7/dist-packages/yandextank/plugins/Influx/plugin.py", line 76, in on_aggregated_data
    self.client.write_points(points, 's')
...
InfluxDBClientError: 400: {"error":"partial write: field type conflict: input field \"planned_requests\" on measurement \"overall_meta\" is type float, already exists as type integer dropped=1"}
```

Also, if you don't mind, I would add `influxdb` to requirements. It is quite a small dependency and shall not cause problems.