### PR TITLE
plugins/Console: fix average response size

### DIFF
--- a/yandextank/plugins/Console/screen.py
+++ b/yandextank/plugins/Console/screen.py
@@ -505,7 +505,7 @@ class AnswSizesBlock(AbstractBlock):
 
     def add_second(self, data):
 
-        self.cur_in = data["overall"]["size_out"]["total"]
+        self.cur_in = data["overall"]["size_in"]["total"]
         self.cur_out = data["overall"]["size_out"]["total"]
         self.cur_count = data["overall"]["interval_real"]["len"]
 


### PR DESCRIPTION
This is a small fix for average response size in Console plugin. Currently it displays the value of request size.

Thanks @kkalinin for figuring it out.