### PR TITLE
AddressWizard regexp update, AddressWizard tests

### DIFF
--- a/yandextank/common/tests/test_util.py
+++ b/yandextank/common/tests/test_util.py
@@ -1,7 +1,9 @@
 from queue import Queue
 from yandextank.common.util import FileScanner
+import socket
 
 from netort.data_processing import Drain, Chopper
+from yandextank.common.util import AddressWizard
 
 
 class TestDrain(object):
@@ -74,3 +76,55 @@ class TestFileScanner(object):
 
     def test_use_custom_separator(self):
         assert self.__process_chunks(["aaa:bbb:ccc:"], ":") == ["aaa", "bbb", "ccc"]
+
+
+class TestAddressResolver(object):
+    @staticmethod
+    def __resolve(chunk):
+        aw = AddressWizard()
+        return aw.resolve(chunk)
+
+    def __resolve_hostname_and_test(self, address_str, test_hostname, test_port):
+        passed = False
+        try:
+            resolved = socket.getaddrinfo(test_hostname, test_port)
+        except Exception:
+            # skip this check if resolver not available
+            return True
+
+        try:
+            for i in resolved:
+                if i[4][1] == self.__resolve(address_str)[2] and i[4][0] == self.__resolve(address_str)[1]:
+                    passed = True
+        except IndexError:
+            pass
+        assert passed
+
+    # ipv6
+    def test_ipv6(self):
+        assert self.__resolve('2a02:6b8::2:242') == (True, '2a02:6b8::2:242', 80, '2a02:6b8::2:242')
+
+    def test_ipv6_braces_port(self):
+        assert self.__resolve('[2a02:6b8::2:242]:666') == (True, '2a02:6b8::2:242', 666, '2a02:6b8::2:242')
+
+    def test_ipv6_braces_port_spaces(self):
+        assert self.__resolve('[ 2a02:6b8::2:242 ]: 666') == (True, '2a02:6b8::2:242', 666, '2a02:6b8::2:242')
+
+    def test_ipv4(self):
+        assert self.__resolve('87.250.250.242') == (False, '87.250.250.242', 80, '87.250.250.242')
+
+    def test_ipv4_port(self):
+        assert self.__resolve('87.250.250.242:666') == (False, '87.250.250.242', 666, '87.250.250.242')
+
+    def test_ipv4_braces_port(self):
+        assert self.__resolve('[87.250.250.242]:666') == (False, '87.250.250.242', 666, '87.250.250.242')
+
+    # hostname
+    def test_hostname_port(self):
+        self.__resolve_hostname_and_test('ya.ru:666', 'ya.ru', '666')
+
+    def test_hostname_braces(self):
+        self.__resolve_hostname_and_test('[ya.ru]', 'ya.ru', '80')
+
+    def test_hostname_braces_port(self):
+        self.__resolve_hostname_and_test('[ya.ru]:666', 'ya.ru', '666')

--- a/yandextank/common/tests/test_util.py
+++ b/yandextank/common/tests/test_util.py
@@ -83,6 +83,7 @@ class TestAddressResolver(object):
     @staticmethod
     def __resolve(chunk):
         aw = AddressWizard()
+        # return format: is_v6, parsed_ip, int(port), address_str
         return aw.resolve(chunk)
 
     def __resolve_hostname_and_test(self, address_str, test_hostname, test_port):

--- a/yandextank/common/tests/test_util.py
+++ b/yandextank/common/tests/test_util.py
@@ -1,9 +1,10 @@
-from queue import Queue
-from yandextank.common.util import FileScanner
 import socket
 
-from netort.data_processing import Drain, Chopper
+from queue import Queue
+from yandextank.common.util import FileScanner
 from yandextank.common.util import AddressWizard
+
+from netort.data_processing import Drain, Chopper
 
 
 class TestDrain(object):

--- a/yandextank/common/util.py
+++ b/yandextank/common/util.py
@@ -475,7 +475,7 @@ class AddressWizard:
             ^
             \[           # opening brace
             \s?          # space sym?
-            (\S+)      # address - string until ]
+            (\S+)        # address - string until ]
             \s?          # space sym?
             \]           # closing brace
             :            # port separator
@@ -487,7 +487,7 @@ class AddressWizard:
             ^
             \[           # opening brace
             \s?          # space sym?
-            (\S+)      # address - string until ]
+            (\S+)        # address - string until ]
             \s?          # space sym?
             \]           # closing brace
             $

--- a/yandextank/common/util.py
+++ b/yandextank/common/util.py
@@ -475,7 +475,7 @@ class AddressWizard:
             ^
             \[           # opening brace
             \s?          # space sym?
-            (\S+)        # address - string until ]
+            (\S+)        # address - string
             \s?          # space sym?
             \]           # closing brace
             :            # port separator
@@ -487,7 +487,7 @@ class AddressWizard:
             ^
             \[           # opening brace
             \s?          # space sym?
-            (\S+)        # address - string until ]
+            (\S+)        # address - string
             \s?          # space sym?
             \]           # closing brace
             $

--- a/yandextank/common/util.py
+++ b/yandextank/common/util.py
@@ -471,16 +471,36 @@ class AddressWizard:
 
         port = None
 
-        braceport_pat = "^\[([^]]+)\]:(\d+)$"
-        braceonly_pat = "^\[([^]]+)\]$"
-        if re.match(braceport_pat, address_str):
+        braceport_re = re.compile(r"""
+            ^
+            \[           # opening brace
+            \s?          # space sym?
+            (\S+)      # address - string until ]
+            \s?          # space sym?
+            \]           # closing brace
+            :            # port separator
+            \s?          # space sym?
+            (\d+)        # port
+            $
+        """, re.X)
+        braceonly_re = re.compile(r"""
+            ^
+            \[           # opening brace
+            \s?          # space sym?
+            (\S+)      # address - string until ]
+            \s?          # space sym?
+            \]           # closing brace
+            $
+        """, re.X)
+
+        if braceport_re.match(address_str):
             logger.debug("Braces and port present")
-            match = re.match(braceport_pat, address_str)
+            match = braceport_re.match(address_str)
             logger.debug("Match: %s %s ", match.group(1), match.group(2))
             address_str, port = match.group(1), match.group(2)
-        elif re.match(braceonly_pat, address_str):
+        elif braceonly_re.match(address_str):
             logger.debug("Braces only present")
-            match = re.match(braceonly_pat, address_str)
+            match = braceonly_re.match(address_str)
             logger.debug("Match: %s", match.group(1))
             address_str = match.group(1)
         else:

--- a/yandextank/plugins/Phantom/utils.py
+++ b/yandextank/plugins/Phantom/utils.py
@@ -356,7 +356,7 @@ class StreamConfig:
             fname = 'phantom_benchmark_main.tpl'
         else:
             fname = 'phantom_benchmark_additional.tpl'
-        template_str = template_str = resource_string(
+        template_str = resource_string(
             __name__, "config/" + fname)
         tpl = string.Template(template_str)
         config = tpl.substitute(kwargs)


### PR DESCRIPTION
AddressWizard now allows for 1 whitespace symbol before/after braces, e.g. 
"[ 192.168.1.1 ]: 80"

https://github.com/yandex/yandex-tank/issues/155