### PR TITLE
deprecated

### DIFF
--- a/yandextank/plugins/Phantom/reader.py
+++ b/yandextank/plugins/Phantom/reader.py
@@ -11,7 +11,7 @@ import time
 import datetime
 import itertools as itt
 
-from pandas.parser import CParserError
+from pandas.io.parser import CParserError
 
 from yandextank.common.interfaces import StatsReader
 


### PR DESCRIPTION
 /var/loadtest # yandex-tank -c load.yaml
/usr/local/lib/python2.7/dist-packages/yandextank/plugins/Phantom/reader.py:14: FutureWarning: The pandas.parser module is deprecated and will be removed in a future version. Please import from pandas.io.parser instead
  from pandas.parser import CParserError
20:32:28 [ERROR] Exception: Validation error:
phantom:
  headers: [must be of list type]
  uris: [must be of list type]