### PR TITLE
JMeter arguments bugfix

### DIFF
--- a/yandextank/plugins/JMeter/plugin.py
+++ b/yandextank/plugins/JMeter/plugin.py
@@ -7,6 +7,7 @@ import subprocess
 import time
 import socket
 import re
+import shlex
 
 from pkg_resources import resource_string
 
@@ -98,7 +99,7 @@ class Plugin(GeneratorPlugin):
             '-Jjmeter.save.saveservice.default_delimiter=\\t',
             '-Jjmeter.save.saveservice.connect_time=true'
         ]
-        self.args += splitstring(self.user_args)
+        self.args += shlex.split(self.user_args)
 
         if self.affinity:
             self.core.__setup_affinity(self.affinity, args=self.args)


### PR DESCRIPTION
'splitstring' breaks space-separated arguments