### PR TITLE
Fix pyyml warnings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ analytic tools for the results they produce.
         'pandas>=0.18.0', 'numpy>=1.11.0', 'future>=0.16.0',
         'pip>=8.1.2',
         'matplotlib>=1.5.3', 'seaborn>=0.7.1',
-        'pyyaml>=3.12', 'cerberus>=1.1'
+        'pyyaml>=pyyaml>=4.2b1', 'cerberus>=1.1'
     ],
     setup_requires=[
         'pytest-runner', 'flake8',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ analytic tools for the results they produce.
         'pandas>=0.18.0', 'numpy>=1.11.0', 'future>=0.16.0',
         'pip>=8.1.2',
         'matplotlib>=1.5.3', 'seaborn>=0.7.1',
-        'pyyaml>=pyyaml>=4.2b1', 'cerberus>=1.1'
+        'pyyaml>=4.2b1', 'cerberus>=1.1'
     ],
     setup_requires=[
         'pytest-runner', 'flake8',

--- a/yandextank/config_converter/tests/test_converter.py
+++ b/yandextank/config_converter/tests/test_converter.py
@@ -91,7 +91,7 @@ def test_parse_package(package_path, expected):
 ])
 def test_convert_ini_phantom(ini_file, yaml_file):
     with open(os.path.join(os.path.dirname(__file__), yaml_file), 'r') as f:
-        assert yaml.dump(convert_ini(os.path.join(os.path.dirname(__file__), ini_file))) == yaml.dump(yaml.load(f))
+        assert yaml.dump(convert_ini(os.path.join(os.path.dirname(__file__), ini_file))) == yaml.dump(yaml.load(f, Loader=yaml.FullLoader))
 
 
 @pytest.mark.parametrize('ini_file, msgs', [

--- a/yandextank/core/consoleworker.py
+++ b/yandextank/core/consoleworker.py
@@ -83,7 +83,7 @@ def load_cfg(cfg_filename):
     """
     if cfg_filename.endswith('.yaml'):
         with open(cfg_filename) as f:
-            cfg = yaml.load(f)
+            cfg = yaml.load(f, Loader=yaml.FullLoader)
     else:
         cfg = convert_ini(cfg_filename)
     return cfg

--- a/yandextank/core/tankcore.py
+++ b/yandextank/core/tankcore.py
@@ -484,7 +484,7 @@ class TankCore(object):
                 logger.info("Lock file is found: %s", full_name)
                 try:
                     with open(full_name) as f:
-                        running_cfg = yaml.load(f)
+                        running_cfg = yaml.load(f, Loader=yaml.FullLoader)
                     pid = running_cfg.get(TankCore.SECTION).get(cls.PID_OPTION)
                     if not pid:
                         logger.warning('Failed to get {}.{} from lock file {}'.format(TankCore.SECTION))

--- a/yandextank/core/tests/test_tankcore.py
+++ b/yandextank/core/tests/test_tankcore.py
@@ -22,7 +22,7 @@ logger.addHandler(console_handler)
 
 def load_yaml(directory, filename):
     with open(os.path.join(directory, filename), 'r') as f:
-        return yaml.load(f)
+        return yaml.load(f, Loader=yaml.FullLoader)
 
 
 CFG1 = {
@@ -200,7 +200,7 @@ def teardown_module(module):
 
 def sort_schema_alphabetically(filename):
     with open(filename, 'r') as f:
-        schema = yaml.load(f)
+        schema = yaml.load(f, Loader=yaml.FullLoader)
     with open(filename, 'w') as f:
         for key in sorted(schema.keys()):
             f.write(key + ':\n')

--- a/yandextank/validator/validator.py
+++ b/yandextank/validator/validator.py
@@ -25,7 +25,7 @@ class ValidationError(Exception):
 def load_yaml_schema(path):
     # DEFAULT_FILENAME = 'schema.yaml'
     with open(path, 'r') as f:
-        return yaml.load(f)
+        return yaml.load(f, Loader=yaml.FullLoader)
 
 
 def load_py_schema(path):


### PR DESCRIPTION
Fix pyyml warnings. 
See alert here: https://github.com/yandex/yandex-tank/network/alert/setup.py/pyyaml/open
I use FullLoader type, but only for compatibility. I think we need to test and implement the SafeLoader type instead.