### PR TITLE
Fix pip not installing dependencies for bfg

### DIFF
--- a/yandextank/plugins/Bfg/plugin.py
+++ b/yandextank/plugins/Bfg/plugin.py
@@ -2,7 +2,8 @@ import logging
 import time
 from threading import Event, Thread
 
-import pip
+import subprocess
+import sys
 
 from .guns import LogGun, SqlGun, CustomGun, HttpGun, ScenarioGun, UltimateGun
 from .reader import BfgReader, BfgStatsReader
@@ -96,7 +97,7 @@ class Plugin(GeneratorPlugin):
         pip_deps = self.get_option("pip", "").splitlines()
         self.log.info("Installing with PIP: %s", pip_deps)
         if pip_deps:
-            retcode = pip.main(["install", "--user"] + pip_deps)
+            retcode = subprocess.check_call([sys.executable, "-m", "pip", "install", "--user"] + pip_deps)
             if retcode != 0:
                 raise RuntimeError("Could not install required deps")
             import site


### PR DESCRIPTION

In the docs for Bfg, it says: 

> pip: Install python modules with pip install --user before the test. If you need multiple modules use multiline options

So, the yaml config like this should work:
```
bfg:
  pip: >
      dep1

      dep2
```

But when you specify dependencies in .yaml file, pip is throwing this exception: 
> AttributeError: 'thread._local' object has no attribute 'indentation'

Upgrading pip doesn't help as pip.main is not available in the recent versions. In the pip docs, they encourage you to use subprocess, so I've changed pip.main to subprocess.check_call and now it works.
