### PR TITLE
fix resource check for linux container on windows docker

### DIFF
--- a/yandextank/plugins/ResourceCheck/plugin.py
+++ b/yandextank/plugins/ResourceCheck/plugin.py
@@ -51,7 +51,7 @@ class Plugin(AbstractPlugin):
 
     def __check_disk(self):
         ''' raise exception on disk space exceeded '''
-        cmd = "sh -c \"df --no-sync -m -P -l -x fuse -x tmpfs -x devtmpfs -x davfs -x nfs "
+        cmd = "sh -c \"df --no-sync -m -P -x fuse -x tmpfs -x devtmpfs -x davfs -x nfs "
         cmd += self.core.artifacts_base_dir
         cmd += " | tail -n 1 | awk '{print \$4}' \""
         res = execute(cmd, True, 0.1, True)


### PR DESCRIPTION
Параметр -l используется для ограничения проверяемых ресурсов только локально-подключенными дисками.
При подключении вольюма в докер контейнер на windows - подключение происходит через внутреннюю докер-сеть и наличие параметра -l ограничивает проверку ресурсов и бросает исключение:
```
df: no file systems processed
```

В докер контейнере на mac - никак не влияет на вывод.