### PR TITLE
Fix empty uploader metainfo in neuploader

### DIFF
--- a/yandextank/plugins/NeUploader/plugin.py
+++ b/yandextank/plugins/NeUploader/plugin.py
@@ -54,8 +54,11 @@ class Plugin(AbstractPlugin, MonitoringDataListener):
             }
 
     def _cleanup(self):
-        uploader_metainfo = self.map_uploader_tags(self.core.status.get('uploader'))
-        self.data_session.update_job(uploader_metainfo)
+        try:
+            uploader_metainfo = self.map_uploader_tags(self.core.status.get('uploader'))
+            self.data_session.update_job(uploader_metainfo)
+        except AttributeError:
+            logging.info('No uploader metainfo found')
         self.data_session.close()
 
     def is_test_finished(self):


### PR DESCRIPTION
When uploader is disabled and neuploader is enabled, cleanup stage crashes because of empty uploader metainfo