### PR TITLE
Support SSL and path for InfluxDB artifact uploader 

### DIFF
--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -99,6 +99,18 @@ InfluxUploader
 ------------------
 *\- (no description). Default:* ``8086``
 
+``ssl`` (boolean)
+------------------
+*\- (no description). Default:* ``False``
+
+``verify_ssl`` (boolean)
+------------------
+*\- (no description). Default:* ``False``
+
+``path`` (string)
+------------------
+*\- (no description). Default:* ``""``
+
 ``prefix_measurement`` (string)
 -------------------------------
 *\- (no description). Default:* ``""``

--- a/docs/core_and_modules.rst
+++ b/docs/core_and_modules.rst
@@ -857,6 +857,12 @@ Options
   (Optional) InfluxDB address. (Default: 'localhost')
 :port:
   (Optional) InfluxDB port. (Default: 8086)
+:ssl:
+  (Optional) Use https instead of http to connect to InfluxDB. (Default: false)
+:verify_ssl:
+  (Optional) Verify SSL certificates for HTTPS requests. (Default: false)
+:path:
+  (Optional) Path of InfluxDB on the server to connect. (Default: '')
 :database:
   (Optional) InfluxDB database. (Default: 'mydb')
 :username:

--- a/yandextank/plugins/InfluxUploader/config/schema.yaml
+++ b/yandextank/plugins/InfluxUploader/config/schema.yaml
@@ -7,6 +7,15 @@ address:
 port:
   default: 8086
   type: integer
+ssl:
+  default: false
+  type: boolean
+verify_ssl:
+  default: false
+  type: boolean
+path:
+  default: ""
+  type: string
 database:
   default: mydb
   type: string

--- a/yandextank/plugins/InfluxUploader/plugin.py
+++ b/yandextank/plugins/InfluxUploader/plugin.py
@@ -53,12 +53,12 @@ class Plugin(AbstractPlugin, AggregateResultListener,
             self._client = InfluxDBClient(
                 self.get_option("address"),
                 self.get_option("port"),
-                username=self.get_option("username"),
-                password=self.get_option("password"),
-                database=self.get_option("database"),
                 ssl=self.get_option("ssl"),
                 verify_ssl=self.get_option("verify_ssl"),
                 path=self.get_option("path"),
+                username=self.get_option("username"),
+                password=self.get_option("password"),
+                database=self.get_option("database"),
             )
         return self._client
 

--- a/yandextank/plugins/InfluxUploader/plugin.py
+++ b/yandextank/plugins/InfluxUploader/plugin.py
@@ -56,6 +56,9 @@ class Plugin(AbstractPlugin, AggregateResultListener,
                 username=self.get_option("username"),
                 password=self.get_option("password"),
                 database=self.get_option("database"),
+                ssl=self.get_option("ssl"),
+                verify_ssl=self.get_option("verify_ssl"),
+                path=self.get_option("path"),
             )
         return self._client
 

--- a/yandextank/plugins/Pandora/reader.py
+++ b/yandextank/plugins/Pandora/reader.py
@@ -32,7 +32,7 @@ class PandoraStatsPoller(Thread):
                             'reqps': pandora_stat.get("engine_ReqPS"),
                         }
                     }
-                except (requests.ConnectionError, requests.HTTPError, requests.exceptions.Timeout):
+                except (requests.ConnectionError, requests.HTTPError, requests.exceptions.Timeout, ValueError):
                     logger.debug("Pandora expvar http interface is unavailable", exc_info=True)
                     data = {
                         'ts': last_ts - 1,


### PR DESCRIPTION
Added more connection options for InfluxDB artifact uploader.
Should also be useful for [metrics ingestion to other tools such as VictoriaMetrics (Prometheus)](https://github.com/VictoriaMetrics/VictoriaMetrics/tree/cluster#url-format), which have the same API as InfluxDB, but often with SSL and additional path.
Sample config for VictoriaMetrics:
```yaml
influx:
  enabled: true
  address: vminsert.example.com
  port: 443
  ssl: true
  verify_ssl: false
  path: '/insert/1/influx/api/v2'

```
Options are added according to [InfluxDB-Python](https://github.com/influxdata/influxdb-python/blob/master/influxdb/client.py#L28) reference.
Defaults shouldn't break existing configs.

Also added `ValueError` exception on Pandora collector because in Docker it seems to take some time for Pandora to expose its metrics, and there is no JSON resulting in that error.