### PR TITLE
Add additional overall metrics and ssl support to influxdb

### DIFF
--- a/yandextank/plugins/InfluxUploader/config/schema.yaml
+++ b/yandextank/plugins/InfluxUploader/config/schema.yaml
@@ -7,6 +7,9 @@ address:
 port:
   default: 8086
   type: integer
+ssl:
+  default: false
+  type: boolean
 database:
   default: mydb
   type: string

--- a/yandextank/plugins/InfluxUploader/decoder.py
+++ b/yandextank/plugins/InfluxUploader/decoder.py
@@ -145,9 +145,18 @@ class Decoder(object):
     @staticmethod
     def __make_overall_meta_fields(data, stats):
         return {
-            "active_threads": stats["metrics"]["instances"],
-            "RPS": data["interval_real"]["len"],
-            "planned_requests": float(stats["metrics"]["reqps"]),
+            "active_threads":
+            stats["metrics"]["instances"],
+            "RPS":
+            data["interval_real"]["len"],
+            "planned_requests":
+            float(stats["metrics"]["reqps"]),
+            "avg_rt":
+            float(data['interval_real']['total']) / data['interval_real']['len'] / 1000.0,
+            "min":
+            data['interval_real']['min'] / 1000.0,
+            "max":
+            data['interval_real']['max'] / 1000.0
         }
 
     @staticmethod

--- a/yandextank/plugins/InfluxUploader/plugin.py
+++ b/yandextank/plugins/InfluxUploader/plugin.py
@@ -51,11 +51,12 @@ class Plugin(AbstractPlugin, AggregateResultListener,
     def client(self):
         if not self._client:
             self._client = InfluxDBClient(
-                self.get_option("address"),
-                self.get_option("port"),
+                host=self.get_option("address"),
+                port=self.get_option("port"),
                 username=self.get_option("username"),
                 password=self.get_option("password"),
                 database=self.get_option("database"),
+                ssl=self.get_option("ssl")
             )
         return self._client
 


### PR DESCRIPTION
Adding extra overall metrics to the influxdb data exporter - now equal to what the OpenTSDB one does.

Additionally, adding an extra configuration parameter to allow for SSL.