### PR TITLE
Update Docker build to avoid OpenSSL problems

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -61,6 +61,8 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 RUN curl -L -v -o pandora https://github.com/yandex/pandora/releases/latest/download/pandora_0.3.8_linux_amd64 && \
     chmod +x ./pandora && \
     mv ./pandora /usr/local/bin/
+    
+RUN pip install pip --upgrade && pip install pyopenssl --upgrade
 
 COPY files/bashrc /root/.bashrc
 COPY files/inputrc /root/.inputrc


### PR DESCRIPTION
On the latest Debian, the tank run resulted in the error below. This image addition fixes it.

```
Traceback (most recent call last):
  File "/usr/local/bin/yandex-tank", line 5, in <module>
    from yandextank.core.cli import main
  File "/usr/local/lib/python3.8/dist-packages/yandextank/core/__init__.py", line 4, in <module>
    from .tankcore import TankCore  # noqa
  File "/usr/local/lib/python3.8/dist-packages/yandextank/core/tankcore.py", line 25, in <module>
    from yandextank.plugins.DataUploader.client import LPRequisites
  File "/usr/local/lib/python3.8/dist-packages/yandextank/plugins/DataUploader/__init__.py", line 1, in <module>
    from .plugin import Plugin  # noqa
  File "/usr/local/lib/python3.8/dist-packages/yandextank/plugins/DataUploader/plugin.py", line 18, in <module>
    import requests
  File "/usr/lib/python3/dist-packages/requests/__init__.py", line 95, in <module>
    from urllib3.contrib import pyopenssl
  File "/usr/lib/python3/dist-packages/urllib3/contrib/pyopenssl.py", line 46, in <module>
    import OpenSSL.SSL
  File "/usr/local/lib/python3.8/dist-packages/OpenSSL/__init__.py", line 8, in <module>
    from OpenSSL import crypto, SSL
  File "/usr/local/lib/python3.8/dist-packages/OpenSSL/crypto.py", line 1550, in <module>
    class X509StoreFlags(object):
  File "/usr/local/lib/python3.8/dist-packages/OpenSSL/crypto.py", line 1570, in X509StoreFlags
    CB_ISSUER_CHECK = _lib.X509_V_FLAG_CB_ISSUER_CHECK
AttributeError: module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK'
```