### PR TITLE
Update setup.py. Add config directory to package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ analytic tools for the results they produce.
         'yandextank.plugins.OpenTSDBUploader': ['config/*'],
         'yandextank.plugins.JMeter': ['config/*'],
         'yandextank.plugins.JsonReport': ['config/*'],
+        'yandextank.plugins.OfflineReport': ['config/*'],
         'yandextank.plugins.Pandora': ['config/*'],
         'yandextank.plugins.Phantom': ['config/*'],
         'yandextank.plugins.RCAssert': ['config/*'],


### PR DESCRIPTION
При билде не попадает директория с конфигом, из-за этого не получается использовать плагин OfflineReport.
Stack:
```
Traceback (most recent call last):
  File \"/usr/local/lib/python3.9/dist-packages/yandextank/validator/validator.py\", line 41, in load_plugin_schema
    return load_yaml_schema(
  File \"/usr/local/lib/python3.9/dist-packages/yandextank/validator/validator.py\", line 30, in load_yaml_schema
    file_content = read_resource(path)
  File \"/usr/local/lib/python3.9/dist-packages/yandextank/common/util.py\", line 34, in read_resource
    with open(path, file_open_mode) as f:
FileNotFoundError: [Errno 2] No such file or directory: '/usr/local/lib/python3.9/dist-packages/yandextank/plugins/OfflineReport/config/schema.yaml'
```