### PR TITLE
fix(stepper): avoid ZeroDivisionError for line(N, N, _) schedule

### DIFF
--- a/yandextank/stepper/instance_plan.py
+++ b/yandextank/stepper/instance_plan.py
@@ -34,6 +34,16 @@ class LoadPlanBuilder(object):
         self.log.debug("Ramp %s instances in %sms from %sms" % (count, duration, self.duration))
         if count < 0:
             raise StepperConfigurationError("Can not stop instances in instances_schedule.")
+        if count == 0:
+            # nothing to start, but the phase still takes time
+            self.duration += duration
+            return self
+        if count == 1:
+            # a single-instance ramp is degenerate: start it now and hold for the
+            # whole duration instead of dividing by zero in `interval`.
+            self.start(1)
+            self.wait(duration)
+            return self
         interval = float(duration) / (count - 1)
         start_time = self.duration
         self.generators.append(int(start_time + i * interval) for i in range(0, count))

--- a/yandextank/stepper/tests/test_instance_plan.py
+++ b/yandextank/stepper/tests/test_instance_plan.py
@@ -27,6 +27,13 @@ class TestCreate(object):
             (7, create(['wait(5s)', 'ramp(5, 0)']), [5000, 5000, 5000, 5000, 5000, 0, 0]),
             (7, create([]), [0, 0, 0, 0, 0, 0, 0]),
             (12, create(['line(1, 9, 4s)']), [0, 500, 1000, 1500, 2000, 2500, 3000, 3500, 4000, 0, 0, 0]),
+            (7, create(['line(5, 5, 3s)']), [0, 0, 0, 0, 0, 0, 0]),
+            (7, create(['ramp(1, 3s)']), [0, 0, 0, 0, 0, 0, 0]),
+            (
+                12,
+                LoadPlanBuilder().line(5, 5, 3000).steps,
+                [(5, 3)],
+            ),
             (
                 12,
                 create(['const(3, 5s)', 'line(7, 11, 2s)']),
@@ -65,6 +72,7 @@ class TestCreate(object):
             (LoadPlanBuilder().stairway(100, 950, 100, 30000), 950),
             (LoadPlanBuilder().const(3, 1000).line(5, 10, 5000), 10),
             (LoadPlanBuilder().line(1, 100, 60000), 100),
+            (LoadPlanBuilder().line(5, 5, 3000), 5),
         ],
     )
     def test_instances(self, loadplan, expected):


### PR DESCRIPTION
Fixes #850.

## Problem

When a load schedule uses `line(initial, final, duration)` with `initial == final` (e.g. `line(5, 5, 30s)`), yandex-tank crashes with:

```
ZeroDivisionError: float division by zero
```

`line()` delegates to `ramp(final - initial + 1, duration)`, which for equal bounds becomes `ramp(1, duration)`. In `ramp()` the interval is computed as `float(duration) / (count - 1)`, so `count == 1` divides by zero.

## Fix

Handle the degenerate cases in `ramp()`:

- `count == 1`: start the single instance immediately and hold for the full duration (`start(1)` + `wait(duration)`), instead of dividing by zero.
- `count == 0`: nothing to start, the phase still consumes time.

`line(N, N, _)` now behaves as holding `N` instances for the given duration (equivalent to `const(N, _)`).

## Tests

Added cases to `test_instance_plan.py`:

- `create(['line(5, 5, 3s)'])` → `[0, 0, 0, 0, 0, 0, 0]`
- `create(['ramp(1, 3s)'])` → `[0, 0, 0, 0, 0, 0, 0]`
- `LoadPlanBuilder().line(5, 5, 3000).steps` → `[(5, 3)]`
- `LoadPlanBuilder().line(5, 5, 3000).instances` → `5`

All 18 tests in `test_instance_plan.py` pass.